### PR TITLE
Fixed linting erros: Function parameters should be aligned vertically…

### DIFF
--- a/Sources/Aurora/SwiftUI/SwiftUI.RemoteImageView.swift
+++ b/Sources/Aurora/SwiftUI/SwiftUI.RemoteImageView.swift
@@ -29,8 +29,8 @@ public struct RemoteImageView<Placeholder: View, ConfiguredImage: View>: View {
     @State var imageData: UIImage?
 
     public init(url: URL,
-         @ViewBuilder placeholder: @escaping () -> Placeholder,
-         @ViewBuilder image: @escaping (Image) -> ConfiguredImage) {
+                @ViewBuilder placeholder: @escaping () -> Placeholder,
+                @ViewBuilder image: @escaping (Image) -> ConfiguredImage) {
         self.url = url
         self.placeholder = placeholder
         self.image = image


### PR DESCRIPTION
… if they're in multiple lines in a declaration.